### PR TITLE
CICD to build evmapp image and push it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+os: linux
+dist: jammy
+language: generic
+addons:
+  apt:
+    packages:
+      - libxml-xpath-perl
+services:
+  - docker
+
+git:
+  depth: false
+
+env:
+  global:
+    - DOCKER_IMAGE_NAME=evmapp
+    - PROD_RELEASE_BRANCH=main
+    - DEV_RELEASE_BRANCH=development
+
+before_script: source ci/setup_env.sh
+
+jobs:
+  include:
+    - name: "Evmapp Docker Image Build"
+      script: ci/docker.sh
+      if: tag IS present

--- a/ci/docker.sh
+++ b/ci/docker.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+set -eEuo pipefail
+
+workdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." &> /dev/null && pwd )"
+docker_image_name="${DOCKER_IMAGE_NAME:-evmapp}"
+aws_ecr_region='us-east-1'
+docker_hub_org='horizenlabs'
+pom_version="${POM_VERSION:-}"
+
+AWS_ACCOUNT_NUMBER="${AWS_ACCOUNT_NUMBER:-}"
+AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID:-}"
+AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY:-}"
+
+DOCKER_USERNAME="${DOCKER_USERNAME:-}"
+DOCKER_PASSWORD="${DOCKER_PASSWORD:-}"
+
+
+# Functions
+function fn_die() {
+  echo -e "$1" >&2
+  exit "${2:-1}"
+}
+
+# Building only dev or prod releases
+docker_tag=""
+if [ "${IS_A_RELEASE}" = "true" ]; then
+  docker_tag="${TRAVIS_TAG}"
+
+  arg_sc_committish="${ARG_SC_COMMITTISH:-${TRAVIS_TAG}}"
+  arg_sc_version="${ARG_SC_VERSION:-${pom_version}}"
+
+  if [ -z "${arg_sc_committish}" ] || [ -z "${arg_sc_version}" ]; then
+    fn_die "Error: ARG_SC_VERSION and/or ARG_SC_COMMITTISH variables are empty for release build. Docker image will not be built.  Exiting ..."
+  fi
+fi
+
+# Building docker image
+if [ -n "${docker_tag}" ]; then
+  echo "" && echo "=== Building Docker Image: ${docker_image_name}:${docker_tag} ===" && echo ""
+
+  docker build -f "${workdir}"/ci/docker/Dockerfile -t "${docker_image_name}:${docker_tag}" \
+    --build-arg ARG_SC_COMMITTISH="${arg_sc_committish}" \
+    --build-arg ARG_SC_VERSION="${arg_sc_version}" \
+    .
+
+  # Installing awscli for publishing to AWS ECR
+  if ! [ -x "$(command -v aws)" ]; then curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" ; unzip awscliv2.zip ; sudo ./aws/install ; fi
+  export PATH=$PATH:/$HOME/.local/bin
+
+  # Publishing to AWS ECR
+  echo "" && echo "=== Publishing Docker images on ECR ===" && echo ""
+  if [ -z "${AWS_ACCOUNT_NUMBER}" ] || [ -z "${AWS_ACCESS_KEY_ID}" ] || [ -z "${AWS_SECRET_ACCESS_KEY}" ]; then
+    echo "Warning: AWS_ACCOUNT_NUMBER and/or AWS_ACCESS_KEY_ID and/or AWS_SECRET_ACCESS_KEY is(are) empty. Docker image is NOT going to be published on AWS ECR !!!"
+  else
+    aws ecr get-login-password --region "${aws_ecr_region}" | docker login --username AWS --password-stdin "${AWS_ACCOUNT_NUMBER}.dkr.ecr.${aws_ecr_region}.amazonaws.com"
+    docker tag "${docker_image_name}:${docker_tag}" "${AWS_ACCOUNT_NUMBER}.dkr.ecr.${aws_ecr_region}.amazonaws.com/${docker_image_name}:${docker_tag}"
+    docker push "${AWS_ACCOUNT_NUMBER}.dkr.ecr.${aws_ecr_region}.amazonaws.com/${docker_image_name}:${docker_tag}"
+  fi
+
+  sleep 5
+
+  # Publishing to DockerHub
+  echo "" && echo "=== Publishing Docker images on DockerHub===" && echo ""
+  if [ -z "${DOCKER_USERNAME}" ] || [ -z "${DOCKER_PASSWORD}" ]; then
+    echo "Warning: DOCKER_USERNAME and/or DOCKER_USERNAME is(are) empty. Docker image is NOT going to be published on DockerHub !!!"
+  else
+    echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin
+    docker tag "${docker_image_name}:${docker_tag}" "index.docker.io/${docker_hub_org}/${docker_image_name}:${docker_tag}"
+    docker push "index.docker.io/${docker_hub_org}/${docker_image_name}:${docker_tag}"
+  fi
+else
+  echo "" && echo "=== The build did NOT satisfy RELEASE build requirements. Docker image is not being created ===" && echo ""
+fi
+
+
+######
+# The END
+######
+echo "" && echo "=== Done ===" && echo ""
+
+exit 0

--- a/ci/docker/Dockerfile
+++ b/ci/docker/Dockerfile
@@ -1,0 +1,132 @@
+## Build stage
+
+# Global ARGS
+
+ARG FROM_IMAGE_BUILD=zencash/sc-ci-base:focal_jdk-11_latest
+
+ARG FROM_IMAGE_RUN=eclipse-temurin:11-jre-focal
+
+FROM $FROM_IMAGE_BUILD as builder
+
+MAINTAINER infrastructure@zensystem.io
+
+# Scoped ARGS
+
+ARG ARG_SC_COMMITTISH
+
+ARG ARG_SC_GITHUB_REPO=https://github.com/HorizenOfficial/eon.git
+
+ENV SC_COMMITTISH=${ARG_SC_COMMITTISH} \
+    SC_GITHUB_REPO=${ARG_SC_GITHUB_REPO} \
+    REPO_DEST='/EON'
+
+SHELL ["/bin/bash", "-c"]
+
+RUN set -euo pipefail && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends dist-upgrade \
+    && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y software-properties-common \
+    && add-apt-repository -y ppa:ethereum/ethereum && apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y gcc libc6-dev solc \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends git \
+    && git clone ${SC_GITHUB_REPO} ${REPO_DEST} && cd ${REPO_DEST} \
+    && git checkout ${SC_COMMITTISH} && mvn install -DskipTests
+
+## EVMAPP stage
+
+FROM ${FROM_IMAGE_RUN} AS evmapp
+
+MAINTAINER infrastructure@zensystem.io
+
+# Scoped ARGS
+
+ARG ARG_SC_VERSION
+
+ARG ARG_SC_JAR_NAME=eon
+
+ARG ARG_SC_MAIN_CLASS=io.horizen.eon.EonApp
+
+ARG ARG_SC_CONF_PATH=/sidechain/config/sc_settings.conf
+
+ARG ARG_GOSU_VERSION=1.14
+
+ARG ARG_TINI_VERSION=v0.19.0
+
+ENV SC_VERSION=${ARG_SC_VERSION} \
+    SC_JAR_NAME=${ARG_SC_JAR_NAME} \
+    SC_MAIN_CLASS=${ARG_SC_MAIN_CLASS} \
+    SC_CONF_PATH=${ARG_SC_CONF_PATH} \
+    GOSU_VERSION=${ARG_GOSU_VERSION} \
+    TINI_VERSION=${ARG_TINI_VERSION} \
+    REPO_DEST='/EON'
+
+WORKDIR /sidechain
+
+SHELL ["/bin/bash", "-c"]
+
+COPY --from=builder ${REPO_DEST}/target/*.jar /sidechain/
+
+COPY --from=builder ${REPO_DEST}/target/lib /sidechain/lib
+
+COPY ci/docker/entrypoint.sh /usr/local/bin/entrypoint.sh
+
+RUN set -euo pipefail && chmod +x /usr/local/bin/entrypoint.sh \
+    && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install apt-utils \
+    && DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends dist-upgrade \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates \
+      curl \
+      dnsutils \
+      gettext-base \
+      libjemalloc2 \
+      jq \
+      netcat-openbsd \
+      apache2-utils \
+    && savedAptMark="$(apt-mark showmanual)" \
+    && if ! command -v gosu &> /dev/null; then \
+      if ! command -v gpg2 &> /dev/null; then \
+        DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends gnupg2 dirmngr; \
+      fi \
+      && dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')" \
+      && curl -sSfL "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch" > /usr/local/bin/gosu \
+      && curl -sSfL "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc" > /usr/local/bin/gosu.asc \
+      && export GNUPGHOME="$(mktemp -d)" \
+      && ( gpg2 --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 || \
+       gpg2 --batch --keyserver hkps://keyserver.ubuntu.com:443 --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 || \
+       gpg2 --batch --keyserver pgp.mit.edu --recv-key B42F6819007F00F88E364FD4036A9C25BF357DD4 ) \
+      && gpg2 --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
+      && ( gpgconf --kill dirmngr || true ) \
+      && ( gpgconf --kill gpg-agent || true ) \
+      && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
+      && unset GNUPGHOME \
+      && chmod +x /usr/local/bin/gosu \
+      && gosu --version; \
+    fi \
+    && if ! command -v tini &> /dev/null; then \
+      if ! command -v gpg2 &> /dev/null; then \
+        DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends gnupg2 dirmngr; \
+      fi \
+      && curl -sSfL "https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini" > /usr/local/bin/tini \
+      && curl -sSfL "https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini.asc" > /usr/local/bin/tini.asc \
+      && export GNUPGHOME="$(mktemp -d)" \
+      && ( gpg2 --batch --keyserver hkps://keys.openpgp.org --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 || \
+       gpg2 --batch --keyserver hkps://keyserver.ubuntu.com:443 --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 || \
+       gpg2 --batch --keyserver pgp.mit.edu --recv-key 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 ) \
+      && gpg2 --batch --verify /usr/local/bin/tini.asc /usr/local/bin/tini \
+      && ( gpgconf --kill dirmngr || true ) \
+      && ( gpgconf --kill gpg-agent || true ) \
+      && rm -rf "$GNUPGHOME" /usr/local/bin/tini.asc \
+      && unset GNUPGHOME \
+      && chmod +x /usr/local/bin/tini \
+      && tini --version; \
+    fi \
+    && apt-mark auto '.*' &> /dev/null && [ -z "$savedAptMark" ] || apt-mark manual $savedAptMark &> /dev/null \
+    && DEBIAN_FRONTEND=noninteractive apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
+    && rm -rf /var/{lib/apt/lists/*,cache/apt/archives/*.deb} /tmp/*
+
+VOLUME ["/sidechain/datadir/"]
+
+VOLUME ["/sidechain/logs/"]
+
+ENTRYPOINT ["/usr/local/bin/tini", "--", "/usr/local/bin/entrypoint.sh"]
+
+# This is a placeholder CMD, the actual CMD is constructed in entrypoint.sh based on ENV vars like this:
+# "java -cp '/sidechain/${ARG_SC_JAR_NAME}-${SC_VERSION}.jar:/sidechain/lib/*' $SC_MAIN_CLASS $SC_CONF_PATH"
+CMD ["/usr/bin/true"]

--- a/ci/docker/entrypoint.sh
+++ b/ci/docker/entrypoint.sh
@@ -1,0 +1,248 @@
+#!/bin/bash
+
+set -euo pipefail
+
+USER_ID="${LOCAL_USER_ID:-9001}"
+GRP_ID="${LOCAL_GRP_ID:-9001}"
+LD_PRELOAD="${LD_PRELOAD:-}"
+
+if [ "$USER_ID" != "0"  ]; then
+    getent group "$GRP_ID" &> /dev/null || groupadd -g "$GRP_ID" user
+    id -u user &> /dev/null || useradd --shell /bin/bash -u "$USER_ID" -g "$GRP_ID" -o -c "" -m user
+    CURRENT_UID="$(id -u user)"
+    CURRENT_GID="$(id -g user)"
+    if [ "$USER_ID" != "$CURRENT_UID" ] || [ "$GRP_ID" != "$CURRENT_GID" ]; then
+        echo -e "WARNING: User with differing UID $CURRENT_UID/GID $CURRENT_GID already exists, most likely this container was started before with a different UID/GID. Re-create it to change UID/GID.\n"
+    fi
+else
+    CURRENT_UID="$USER_ID"
+    CURRENT_GID="$GRP_ID"
+    echo -e "WARNING: Starting container processes as root. This has some security implications and goes against docker best practice.\n"
+fi
+
+# set $HOME
+if [ "$CURRENT_UID" != "0" ]; then
+    export USERNAME=user
+    export HOME=/home/"$USERNAME"
+else
+    export USERNAME=root
+    export HOME=/root
+fi
+
+# detect external IPv4 address
+SCNODE_NET_DECLAREDADDRESS="$(dig -4 +short +time=2 @resolver1.opendns.com A myip.opendns.com | grep -v ";" || true)"
+
+# Using diff resolver
+if [ -z "${SCNODE_NET_DECLAREDADDRESS}" ]; then
+  SCNODE_NET_DECLAREDADDRESS="$(curl -s ifconfig.me/ip || true)"
+fi
+
+# Falling over to internal IP
+if [ -z "${SCNODE_NET_DECLAREDADDRESS}" ]; then
+  echo "Error: Failed to detect external IPv4 address, using internal address."
+  SCNODE_NET_DECLAREDADDRESS="$(hostname -I | cut -d ' ' -f1)"
+  SCNODE_NET_DECLAREDADDRESS="${SCNODE_NET_DECLAREDADDRESS%% }"
+fi
+export SCNODE_NET_DECLAREDADDRESS
+
+to_check=(
+  "SCNODE_CERT_SIGNERS_MAXPKS"
+  "SCNODE_CERT_SIGNERS_PUBKEYS"
+  "SCNODE_CERT_SIGNERS_THRESHOLD"
+  "SCNODE_CERT_SIGNING_ENABLED"
+  "SCNODE_CERT_MASTERS_PUBKEYS"
+  "SCNODE_CERT_SUBMITTER_ENABLED"
+  "SCNODE_FORGER_ENABLED"
+  "SCNODE_FORGER_RESTRICT"
+  "SCNODE_GENESIS_BLOCKHEX"
+  "SCNODE_GENESIS_SCID"
+  "SCNODE_GENESIS_POWDATA"
+  "SCNODE_GENESIS_MCBLOCKHEIGHT"
+  "SCNODE_GENESIS_MCNETWORK"
+  "SCNODE_GENESIS_WITHDRAWALEPOCHLENGTH"
+  "SCNODE_GENESIS_COMMTREEHASH"
+  "SCNODE_GENESIS_ISNONCEASING"
+  "SCNODE_NET_DECLAREDADDRESS"
+  "SCNODE_NET_KNOWNPEERS"
+  "SCNODE_NET_MAGICBYTES"
+  "SCNODE_NET_NODENAME"
+  "SCNODE_NET_P2P_PORT"
+  "SCNODE_REST_PORT"
+  "SCNODE_WALLET_SEED"
+  "SCNODE_WALLET_MAXTX_FEE"
+  "SCNODE_WS_SERVER_PORT"
+  "SCNODE_WS_CLIENT_ENABLED"
+  "SCNODE_WS_SERVER_ENABLED"
+)
+for var in "${to_check[@]}"; do
+  if [ -z "${!var:-}" ]; then
+    echo "Error: Environment variable ${var} required."
+    sleep 5
+    exit 1
+  fi
+done
+
+if [ "${SCNODE_FORGER_RESTRICT:-}" = "true" ]; then
+  if [ -z "${SCNODE_ALLOWED_FORGERS:-}" ]; then
+    echo "Error: Environment variable SCNODE_ALLOWED_FORGERS required when SCNODE_FORGER_RESTRICT=true."
+    sleep 5
+    exit 1
+  fi
+fi
+
+if [ "${SCNODE_CERT_SIGNING_ENABLED:-}" = "true" ]; then
+  if [ -z "${SCNODE_CERT_SIGNERS_SECRETS:-}" ]; then
+    echo "Error: Environment variable SCNODE_CERT_SIGNERS_SECRETS required when SCNODE_CERT_SIGNING_ENABLED=true or SCNODE_CERT_SUBMITTER_ENABLED=true."
+    sleep 5
+    exit 1
+  fi
+fi
+
+if [ "${SCNODE_FORGER_ENABLED:-}" = "true" ] || [ "${SCNODE_CERT_SUBMITTER_ENABLED:-}" = "true" ]; then
+  if [ -z "${SCNODE_WS_ZEN_FQDN:-}" ]; then
+    echo "Error: Environment variable SCNODE_WS_ZEN_FQDN is required when SCNODE_FORGER_ENABLED=true or SCNODE_CERT_SUBMITTER_ENABLED=true."
+    sleep 5
+    exit 1
+  fi
+fi
+
+# set REST API password hash
+SCNODE_REST_APIKEYHASH=""
+if [ -n "${SCNODE_REST_PASSWORD:-}" ]; then
+  SCNODE_REST_APIKEYHASH="$(echo -en "\n        apiKeyHash = \"$(htpasswd -nbBC 10 "" "${SCNODE_REST_PASSWORD}" | tr -d ':\n')\"")"
+fi
+export SCNODE_REST_APIKEYHASH
+
+# setting maxIncomingConnections if provided
+MAX_INCOMING_CONNECTIONS=""
+if [ -n "${SCNODE_NET_MAX_IN_CONNECTIONS:-}" ]; then
+  MAX_INCOMING_CONNECTIONS="$(echo -en "\n        maxIncomingConnections = ${SCNODE_NET_MAX_IN_CONNECTIONS}")"
+fi
+export MAX_INCOMING_CONNECTIONS
+
+# setting maxOutgoingConnections if provided
+MAX_OUTGOING_CONNECTIONS=""
+if [ -n "${SCNODE_NET_MAX_OUT_CONNECTIONS:-}" ]; then
+  MAX_OUTGOING_CONNECTIONS="$(echo -en "\n        maxOutgoingConnections = ${SCNODE_NET_MAX_OUT_CONNECTIONS}")"
+fi
+export MAX_OUTGOING_CONNECTIONS
+
+# download and extract backup for import
+backupdir="/sidechain/datadir/backupStorage"
+if [ -n "${SCNODE_BACKUP_TAR_GZ_URL:-}" ] && ! [ -f "${backupdir}/.import_done" ]; then
+  echo "Importing backup from '${SCNODE_BACKUP_TAR_GZ_URL}' to '${backupdir}'."
+  mkdir -p "${backupdir}"
+  curl -L "${SCNODE_BACKUP_TAR_GZ_URL}" | tar -xzf - -C "${backupdir}"
+  touch "${backupdir}/.import_done"
+fi
+
+# detect zend container IP, check zend is up and websocket port is reachable
+WS_ADDRESS=""
+if [ -n "${SCNODE_WS_ZEN_FQDN:-}" ]; then
+  to_check=(
+    "RPC_PASSWORD"
+    "RPC_PORT"
+    "RPC_USER"
+    "SCNODE_WS_ZEN_PORT"
+  )
+  for var in "${to_check[@]}"; do
+    if [ -z "${!var:-}" ]; then
+      echo "Error: Environment variable ${var} required when SCNODE_WS_ZEN_FQDN is set."
+      sleep 5
+      exit 1
+    fi
+  done
+
+  # detect IP address
+  i=0
+  while true; do
+    SCNODE_WS_ZEN_IP="$(dig A +short "${SCNODE_WS_ZEN_FQDN}" | grep -v ";" || true)"
+    if [ -n "${SCNODE_WS_ZEN_IP:-}" ]; then
+      break
+    fi
+    sleep 5
+    i="$((i+1))"
+    if [ "$i" -gt 48 ]; then
+      echo "Error: Failed to detect IP address of '${SCNODE_WS_ZEN_FQDN}' container after 4 minutes."
+      exit 1
+    fi
+  done
+  export SCNODE_WS_ZEN_IP
+  echo "Detected IP address '${SCNODE_WS_ZEN_IP}' of '${SCNODE_WS_ZEN_FQDN}' container."
+
+  # make sure zend is up by checking RPC interface
+  i=0
+  while [ -n "$( (curl -s --data-binary '{"jsonrpc": "1.0", "id":"curltest", "method": "getblockcount", "params": [] }' -H 'content-type: text/plain;' -u "${RPC_USER}:${RPC_PASSWORD}" "http://${SCNODE_WS_ZEN_IP}:${RPC_PORT}/" || echo '{"error":"connection error"}') | jq 'select(has("code") or has("error") and ."error" != null)')" ]; do
+    echo "Waiting for '${SCNODE_WS_ZEN_FQDN}' container to be ready."
+    sleep 5
+    i="$((i+1))"
+    if [ "$i" -gt 48 ]; then
+      echo "Error: '${SCNODE_WS_ZEN_FQDN}' container not ready after 4 minutes."
+      exit 1
+    fi
+  done
+  echo "RPC server of '${SCNODE_WS_ZEN_FQDN}' container ready."
+
+  # make sure websocket port is reachable
+  i=0
+  while ! nc -z "${SCNODE_WS_ZEN_IP}" "${SCNODE_WS_ZEN_PORT}" &> /dev/null; do
+    echo "Waiting for '${SCNODE_WS_ZEN_FQDN}' container websocket port to be ready."
+    sleep 5
+    i="$((i+1))"
+    if [ "$i" -gt 48 ]; then
+      echo "Error: '${SCNODE_WS_ZEN_FQDN}' container websocket port not ready after 4 minutes."
+      exit 1
+    fi
+  done
+  echo "Websocket server of '${SCNODE_WS_ZEN_FQDN}' container ready."
+
+  # Setting websocket address option under conf file
+  WS_ADDRESS="ws://${SCNODE_WS_ZEN_IP}:${SCNODE_WS_ZEN_PORT}"
+fi
+export WS_ADDRESS
+
+# convert literal '\n' to newlines
+SCNODE_CERT_SIGNERS_PUBKEYS="$(echo -e "${SCNODE_CERT_SIGNERS_PUBKEYS:-}")"
+SCNODE_CERT_SIGNERS_SECRETS="$(echo -e "${SCNODE_CERT_SIGNERS_SECRETS:-}")"
+SCNODE_CERT_MASTERS_PUBKEYS="$(echo -e "${SCNODE_CERT_MASTERS_PUBKEYS:-}")"
+SCNODE_ALLOWED_FORGERS="$(echo -e "${SCNODE_ALLOWED_FORGERS:-}")"
+SCNODE_NET_KNOWNPEERS="$(echo -e "${SCNODE_NET_KNOWNPEERS:-}")"
+export SCNODE_CERT_SIGNERS_PUBKEYS
+export SCNODE_CERT_SIGNERS_SECRETS
+export SCNODE_CERT_MASTERS_PUBKEYS
+export SCNODE_ALLOWED_FORGERS
+export SCNODE_NET_KNOWNPEERS
+
+# substitute env vars in scnode config file
+# shellcheck disable=SC2016,SC2026
+SUBST='$SCNODE_CERT_MASTERS_PUBKEYS:$SCNODE_CERT_SIGNERS_MAXPKS:$SCNODE_CERT_SIGNERS_PUBKEYS:$SCNODE_CERT_SIGNERS_SECRETS:$SCNODE_CERT_SIGNERS_THRESHOLD:$SCNODE_CERT_SIGNING_ENABLED:'\
+'$SCNODE_CERT_SUBMITTER_ENABLED:$SCNODE_GENESIS_BLOCKHEX:$SCNODE_GENESIS_SCID:$SCNODE_GENESIS_POWDATA:$SCNODE_GENESIS_MCBLOCKHEIGHT:$SCNODE_GENESIS_MCNETWORK:'\
+'$SCNODE_GENESIS_WITHDRAWALEPOCHLENGTH:$SCNODE_GENESIS_COMMTREEHASH:$SCNODE_GENESIS_ISNONCEASING:$SCNODE_ALLOWED_FORGERS:$SCNODE_FORGER_ENABLED:$SCNODE_FORGER_RESTRICT:'\
+'$SCNODE_NET_DECLAREDADDRESS:$SCNODE_NET_KNOWNPEERS:$SCNODE_NET_MAGICBYTES:$SCNODE_NET_NODENAME:$SCNODE_NET_P2P_PORT:$SCNODE_REST_APIKEYHASH:$SCNODE_REST_PORT:'\
+'$SCNODE_WALLET_GENESIS_SECRETS:$SCNODE_WALLET_MAXTX_FEE:$SCNODE_WALLET_SEED:$WS_ADDRESS:$MAX_INCOMING_CONNECTIONS:$MAX_OUTGOING_CONNECTIONS:$SCNODE_WS_SERVER_PORT:'\
+'$SCNODE_WS_CLIENT_ENABLED:$SCNODE_WS_SERVER_ENABLED'
+export SUBST
+envsubst "${SUBST}" < /sidechain/config/sc_settings.conf.tmpl > /sidechain/config/sc_settings.conf
+unset SUBST
+
+# set file ownership
+find /sidechain -writable -print0 | xargs -0 -I{} -P64 -n1 chown -f "${CURRENT_UID}":"${CURRENT_GID}" "{}"
+
+# preload libjemalloc2
+path_to_jemalloc="$(ldconfig -p | grep "$(arch)" | grep 'libjemalloc\.so\.2$' | tr -d ' ' | cut -d '>' -f 2)"
+export LD_PRELOAD="${path_to_jemalloc}:${LD_PRELOAD}"
+
+if [ "${1}" = "/usr/bin/true" ]; then
+  set -- java -cp '/sidechain/'"${SC_JAR_NAME}"'-'"${SC_VERSION}"'.jar:/sidechain/lib/*' $SC_MAIN_CLASS $SC_CONF_PATH
+fi
+
+echo "Username: ${USERNAME}, UID: ${CURRENT_UID}, GID: ${CURRENT_GID}"
+echo "LD_PRELOAD: ${LD_PRELOAD}"
+echo "Starting sidechain node."
+echo "Command: '$@'"
+
+if [ "${USERNAME}" = "user" ]; then
+    exec /usr/local/bin/gosu user "$@"
+else
+    exec "$@"
+fi

--- a/ci/setup_env.sh
+++ b/ci/setup_env.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+set -eo pipefail
+
+export IS_A_RELEASE="false"
+
+POM_VERSION="$(xpath -q -e '/project/version/text()' pom.xml)"
+export POM_VERSION
+
+if [ -z "${TRAVIS_TAG}" ]; then
+  echo "TRAVIS_TAG:                           No TAG"
+else
+  echo "TRAVIS_TAG:                           ${TRAVIS_TAG}"
+fi
+echo "package version:                      ${POM_VERSION}"
+
+
+# Functions
+function import_gpg_keys() {
+  # shellcheck disable=SC2207
+  declare -r my_arr=( $(echo "${@}" | tr " " "\n") )
+
+  if [ "${#my_arr[@]}" -eq 0 ]; then
+    echo "Warning: there are ZERO gpg keys to import. Please check if *MAINTAINERS_KEYS variable(s) are set correctly. The build is not going to be released ..."
+    export IS_A_RELEASE="false"
+  else
+    # shellcheck disable=SC2145
+    printf "%s\n" "Tagged build, fetching keys:" "${@}" ""
+    for key in "${my_arr[@]}"; do
+      gpg -v --batch --keyserver hkps://keys.openpgp.org --recv-keys "${key}" ||
+      gpg -v --batch --keyserver hkp://keyserver.ubuntu.com --recv-keys "${key}" ||
+      gpg -v --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "${key}" ||
+      gpg -v --batch --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys "${key}" ||
+      { echo -e "Warning: ${key} can not be found on GPG key servers. Please upload it to at least one of the following GPG key servers:\nhttps://keys.openpgp.org/\nhttps://keyserver.ubuntu.com/\nhttps://pgp.mit.edu/"; export IS_A_RELEASE="false"; }
+    done
+  fi
+}
+
+function check_signed_tag() {
+  local tag="${1}"
+
+  # Checking if git tag signed by the maintainers
+  if git verify-tag -v "${tag}"; then
+    echo "${tag} is a valid signed tag"
+    export IS_A_RELEASE="true"
+  else
+    echo "" && echo "=== Warning: GIT's tag = ${tag} signature is NOT valid. The build is not going to be released ... ===" && echo ""
+  fi
+}
+
+# Checking if it a release build
+if [ -n "${TRAVIS_TAG}" ]; then
+  echo "The current production branch is: ${PROD_RELEASE_BRANCH}"
+  echo "The current development branch is: ${DEV_RELEASE_BRANCH}"
+
+  # checking if PROD_MAINTAINERS_KEYS and DEV_MAINTAINERS_KEYS are set
+  if [[ -z "${PROD_MAINTAINERS_KEYS}" || -z "${DEV_MAINTAINERS_KEYS}" ]]; then
+    echo "Warning: PROD_MAINTAINERS_KEYS and/or DEV_MAINTAINERS_KEYS variables are not set. Make sure to set it up for PROD|DEV release build !!!"
+  fi
+  all_maintainers_keys=$(echo "${PROD_MAINTAINERS_KEYS} ${DEV_MAINTAINERS_KEYS}" | xargs -n1 | sort -u | xargs)
+
+  # Prod vs development release
+  if ( git branch -r --contains "${TRAVIS_TAG}" | grep -xqE ". origin\/${PROD_RELEASE_BRANCH}$" ); then
+    import_gpg_keys "${PROD_MAINTAINERS_KEYS}"
+    check_signed_tag "${TRAVIS_TAG}"
+
+    if ! [[ "${POM_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-RC[0-9]+)?$ ]]; then
+      echo "Warning: package version under pom.xml file = ${POM_VERSION} is in the wrong format for production release. Expecting: d.d.d(-RC[0-9]+)?. The build is not going to be released !!!"
+      export IS_A_RELEASE="false"
+    fi
+
+    # Checking Github tag format
+    if ! [[ "${TRAVIS_TAG}" == "${POM_VERSION}" ]]; then
+      echo "" && echo "=== Warning: GIT tag format differs from the pom file version. ===" && echo ""
+      echo -e "Github tag name: ${TRAVIS_TAG}\nPom file version: ${POM_VERSION}.\nThe build is not going to be released !!!"
+      export IS_A_RELEASE="false"
+    fi
+
+    if [ "${IS_A_RELEASE}" = "true" ]; then
+      echo "" && echo "=== Production release ===" && echo ""
+    fi
+  elif ( git branch -r --contains "${TRAVIS_TAG}" | grep -xqE ". origin\/${DEV_RELEASE_BRANCH}$" ); then
+    import_gpg_keys "${all_maintainers_keys}"
+    check_signed_tag "${TRAVIS_TAG}"
+
+    if ! [[ "${POM_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-RC[0-9]+)?(-SNAPSHOT){1}$ ]]; then
+      echo "Warning: package version under pom.xml file = ${POM_VERSION} is in the wrong format for development release. Expecting: d.d.d(-RC[0-9]+)?(-SNAPSHOT){1}. The build is not going to be released !!!"
+      IS_A_RELEASE="false"
+    fi
+
+    # Checking Github tag format
+    if ! [[ "${TRAVIS_TAG}" =~ "${POM_VERSION}"[0-9]*$ ]]; then
+      echo "" && echo "=== Warning: GIT tag format differs from the pom file version. ===" && echo ""
+      echo -e "Github tag name: ${TRAVIS_TAG}\nPom file version: ${POM_VERSION}.\nThe build is not going to be released !!!"
+      export IS_A_RELEASE="false"
+    fi
+
+    if [ "${IS_A_RELEASE}" = "true" ]; then
+      echo "" && echo "=== Development release ===" && echo ""
+    fi
+  fi
+fi
+
+# Final check for release vs non-release build
+if [ "${IS_A_RELEASE}" = "false" ]; then
+  echo "" && echo "=== NOT a release build ===" && echo ""
+fi
+
+set +eo pipefail


### PR DESCRIPTION
This PR introduces CICD for building docker image of EON app. There are couple of things I would like to ask @paolocappelletti if we can do a bit diff on this repo to match with our other releases repos like SDK, cryptolib, sparkz and etc.

1) Can we build PROD versions ONLY off `main` branch and it has to be in the format of `digit.digit.digit`
2) Can we build DEV versions ONLY off `development` branch and it has to be in the format of `digit.digit.digit-SNAPSHOT` Keep it in mind SNAPSHOT without any digits after. However, GITHUB TAG can be named `digit.digit.digit-SNAPSHOT[0-9]*` if needed. By doing this we will ensure new code is being released but version of the PACKAGE stays the same from within APP level.

I will be happy to hear some comments, concerns regarding this. 

P.S. We will be adding `mvn` build and test commands to the pipeline in the nearest future as well.