### PR TITLE
EON version binding

### DIFF
--- a/node/src/main/java/io/horizen/eon/EonAppModule.java
+++ b/node/src/main/java/io/horizen/eon/EonAppModule.java
@@ -96,5 +96,14 @@ public class EonAppModule extends AccountAppModule {
         bind(Integer.class)
                 .annotatedWith(Names.named("ConsensusSecondsInSlot"))
                 .toInstance(CONSENSUS_SLOT_TIME);
+
+        bind(String.class)
+                .annotatedWith(Names.named("EonVersion"))
+                .toInstance(getEONVersion());
+    }
+
+    public String getEONVersion() {
+        Package eonPackage = this.getClass().getPackage();
+        return eonPackage.getImplementationVersion();
     }
 }

--- a/node/src/main/java/io/horizen/eon/EonAppModule.java
+++ b/node/src/main/java/io/horizen/eon/EonAppModule.java
@@ -103,7 +103,9 @@ public class EonAppModule extends AccountAppModule {
     }
 
     public String getEONVersion() {
+        String defaultVersion = "dev";
         Package eonPackage = this.getClass().getPackage();
-        return eonPackage.getImplementationVersion();
+        String version = eonPackage.getImplementationVersion();
+        return version != null ? version : defaultVersion;
     }
 }

--- a/node/src/main/java/io/horizen/eon/EonAppModule.java
+++ b/node/src/main/java/io/horizen/eon/EonAppModule.java
@@ -104,10 +104,10 @@ public class EonAppModule extends AccountAppModule {
 
     /**
      Retrieves the EON version by dynamically accessing the implementation version of the package at runtime.
-     The implementation version is taken from JAR file's manifest file <b>Implementation-Version</b> attribute. That attribute
-     is populated when JAR is build with value of version tag under project key from pom file. <br/>
+     The implementation version is taken from the JAR file's manifest file <b>Implementation-Version</b> attribute. That attribute
+     is populated when JAR is built with the value of the version tag under the project key from the pom file. <br/>
      When running the application in a development environment (e.g., directly from the source code or an IDE), the implementation
-     version is not accessible and will return default "dev" value.
+     version is not accessible and will return the default "dev" value.
 
      @return The EON version, or "dev" if the version is not available.
      */

--- a/node/src/main/java/io/horizen/eon/EonAppModule.java
+++ b/node/src/main/java/io/horizen/eon/EonAppModule.java
@@ -98,7 +98,7 @@ public class EonAppModule extends AccountAppModule {
                 .toInstance(CONSENSUS_SLOT_TIME);
 
         bind(String.class)
-                .annotatedWith(Names.named("EonVersion"))
+                .annotatedWith(Names.named("AppVersion"))
                 .toInstance(getEONVersion());
     }
 

--- a/node/src/main/java/io/horizen/eon/EonAppModule.java
+++ b/node/src/main/java/io/horizen/eon/EonAppModule.java
@@ -102,6 +102,15 @@ public class EonAppModule extends AccountAppModule {
                 .toInstance(getEONVersion());
     }
 
+    /**
+     Retrieves the EON version by dynamically accessing the implementation version of the package at runtime.
+     The implementation version is taken from JAR file's manifest file <b>Implementation-Version</b> attribute. That attribute
+     is populated when JAR is build with value of version tag under project key from pom file. <br/>
+     When running the application in a development environment (e.g., directly from the source code or an IDE), the implementation
+     version is not accessible and will return default "dev" value.
+
+     @return The EON version, or "dev" if the version is not available.
+     */
     public String getEONVersion() {
         String defaultVersion = "dev";
         Package eonPackage = this.getClass().getPackage();


### PR DESCRIPTION
[Jira ticket](https://horizenlabs.atlassian.net/browse/SDK-1207?atlOrigin=eyJpIjoiYWExMDcyNjY4ZGI0NDNlODg1ZWY4ZDFkOGY1ZGI5NzQiLCJwIjoiaiJ9)

EON version is taken from the class package implementation version which is specified in pom.xml file. When running EON from IDE, it returns `null` because the implementation version is populated when JAR is built. It follows the logic of sdk version taken from [here](https://github.com/HorizenOfficial/Sidechains-SDK/blob/7729cae9fd10670e57f02decc418b552906eab0c/sdk/src/main/scala/io/horizen/account/api/rpc/service/RpcUtils.scala#LL16C1-L17C1).