### PR TITLE
EON version reading from pom.xml fix

### DIFF
--- a/bootstraptool/pom.xml
+++ b/bootstraptool/pom.xml
@@ -58,6 +58,7 @@
                                     <addClasspath>true</addClasspath>
                                     <classpathPrefix>lib/</classpathPrefix>
                                     <mainClass>io.horizen.bootstraptool.EonBootstrappingTool</mainClass>
+                                    <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
                                 </manifest>
                             </archive>
                         </configuration>
@@ -101,6 +102,7 @@
                                     <addClasspath>true</addClasspath>
                                     <classpathPrefix>lib/</classpathPrefix>
                                     <mainClass>io.horizen.bootstraptool.EonBootstrappingToolPregobi</mainClass>
+                                    <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
                                 </manifest>
                             </archive>
                             <finalName>${project.artifactId}-${project.version}-pregobi</finalName>
@@ -145,6 +147,7 @@
                                     <addClasspath>true</addClasspath>
                                     <classpathPrefix>lib/</classpathPrefix>
                                     <mainClass>io.horizen.bootstraptool.EonBootstrappingToolGobi</mainClass>
+                                    <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
                                 </manifest>
                             </archive>
                             <finalName>${project.artifactId}-${project.version}-gobi</finalName>

--- a/node/pom.xml
+++ b/node/pom.xml
@@ -63,6 +63,18 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>3.3.0</version>
+        <configuration>
+          <archive>
+            <manifest>
+              <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+            </manifest>
+          </archive>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
[Jira ticket](https://horizenlabs.atlassian.net/browse/SDK-1480?atlOrigin=eyJpIjoiYWJkNTgxMDZlYTdlNDQzZDgyZjYxZWU5NzMwM2I5NDYiLCJwIjoiaiJ9)

The problem was that the EON version was not included in the manifest file when building jar. This fix adds maven-jar-plugin to eon's pom to enable writing implementation version to manifest file. Additionally, the implementation version is added to the manifest file of the bootstrapping tool.

The fix is checked by building EON jar and running it from the terminal.

![image](https://github.com/HorizenOfficial/eon/assets/119593972/b6383998-af0e-43a3-ab38-89a2018c384a)
