### PR TITLE
Adding CPU flag check for evmapp entrypoint.sh

### DIFF
--- a/dockerfiles/evmapp/entrypoint.sh
+++ b/dockerfiles/evmapp/entrypoint.sh
@@ -3,7 +3,7 @@ set -eEuo pipefail
 
 # check if this is an unsupported CPU, warn the user and bail
 if ! grep -iq adx /proc/cpuinfo || ! grep -iq bmi2 /proc/cpuinfo; then
-  echo "Error: the host does not support the required adx and bmi2 CPU flags. The application cannot run on older CPUs. Exiting..."
+  echo "Error: the host does not support the required 'adx' and 'bmi2' CPU flags. The application cannot run on older CPUs. Exiting..."
   sleep 5
   exit 1
 fi

--- a/dockerfiles/evmapp/entrypoint.sh
+++ b/dockerfiles/evmapp/entrypoint.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
 set -eEuo pipefail
 
+# check if this is an unsupported CPU, warn the user and bail
+if ! grep -iq adx /proc/cpuinfo || ! grep -iq bmi2 /proc/cpuinfo; then
+  echo "Error: the host does not support the required adx and bmi2 CPU flags. The application cannot run on older CPUs. Exiting..."
+  sleep 5
+  exit 1
+fi
+
+
 USER_ID="${LOCAL_USER_ID:-9001}"
 GRP_ID="${LOCAL_GRP_ID:-9001}"
 LD_PRELOAD="${LD_PRELOAD:-}"


### PR DESCRIPTION
## Description
Add check for ADX and BMI2 flags to EON docker container and DO not start the APP if required flags are not supported

## Jira Ticket
https://horizenlabs.atlassian.net/browse/DEVOP-1685

## Changes
entrypoint.sh for EON 
 
## Additional information
Please make sure this gets into 1.3.0 release
