### PR TITLE
Fix for issue EON-1857

### DIFF
--- a/doc/api/transaction/updateForger.md
+++ b/doc/api/transaction/updateForger.md
@@ -4,7 +4,7 @@
 Updates an existing forger.<br>
 Available from: EON 1.4.0<br>
 
-Note: this action can be performed only for forgers with rewardShare = 0 and rewardAddress not set, and only to assign them a value.<br>
+Note: this action can be performed only for forgers with rewardShare = 0 and rewardAddress not set, and only to assign them a value. This operation can be called only if at least 2 epochs are passed by since the 1.4 fork activation.<br>
 
 **Parameters**
 

--- a/doc/nativesc/contracts/ForgerStakesV2.md
+++ b/doc/nativesc/contracts/ForgerStakesV2.md
@@ -35,7 +35,8 @@ This native smart contract manages the forger stakes from EON 1.4.0 version.
 
      Updates an existing forger.<br>
      A forger can be updated just once and only if rewardAddress == 0x000..00 and rewardShare == 0.<br>
-     Vrf key is split in two separate parameters, being longer than 32 bytes.
+     Vrf key is split in two separate parameters, being longer than 32 bytes.<br>
+     This operation should be called only if at least 2 epochs are passed by since the 1.4 fork activation.
 
 - delegate
 

--- a/doc/nativesc/contracts/ForgerStakesV2.sol
+++ b/doc/nativesc/contracts/ForgerStakesV2.sol
@@ -59,6 +59,7 @@ interface ForgerStakesV2 {
       Updates an existing forger.
       A forger can be updated just once and only if rewardAddress == 0x000..00 and rewardShare == 0.
       See above the registerForger command for the parameters meaning.
+      This operation should be called only if at least 2 epochs are passed by since the 1.4 fork activation.
     */
     function updateForger(bytes32 signPubKey, bytes32 vrf1, bytes1 vrf2, uint32 rewardShare,
         address rewardAddress, bytes32 sign1_1, bytes32 sign1_2,

--- a/node/src/main/java/io/horizen/eon/forks/F6Fork.java
+++ b/node/src/main/java/io/horizen/eon/forks/F6Fork.java
@@ -45,7 +45,10 @@ public class F6Fork extends EONFork {
                                 getActivationRegtest(),
                                 getActivationTestnet(sidechainId),
                                 getActivationMainnet()),
-                        new Version1_4_0Fork(true)
+                        new Version1_4_0Fork(true,
+                                getActivationRegtest(),
+                                getActivationTestnet(sidechainId),
+                                getActivationMainnet())
                 )
         );
     }

--- a/node/src/main/java/io/horizen/eon/forks/F6Fork.java
+++ b/node/src/main/java/io/horizen/eon/forks/F6Fork.java
@@ -45,10 +45,7 @@ public class F6Fork extends EONFork {
                                 getActivationRegtest(),
                                 getActivationTestnet(sidechainId),
                                 getActivationMainnet()),
-                        new Version1_4_0Fork(true,
-                                getActivationRegtest(),
-                                getActivationTestnet(sidechainId),
-                                getActivationMainnet())
+                        new Version1_4_0Fork(true)
                 )
         );
     }


### PR DESCRIPTION
Fix for issue [EON-1857](https://horizenlabs.atlassian.net/browse/EON-1857)

The fix consists in preventing the `updateForger` operation for the 2 epochs after the 1.4 fork activation, assuming that the V2 activation happens in the same epoch.

This fix has a companion fix in Sidechain-Sdk repository: https://github.com/HorizenOfficial/Sidechains-SDK/pull/1037
